### PR TITLE
[DOCS] Adds new sections to the serverless getting started page

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -97,7 +97,10 @@ const result = await client.helpers.bulk({
 You can get documents by using the following code:
 
 ```js
-
+await client.get({
+  index: 'books',
+  id: 'a_document_id',
+})
 ```
 
 
@@ -124,7 +127,14 @@ console.log(result.hits.hits)
 You can call the `update` API to update a document:
 
 ```js
-
+await client.update({
+  index: 'books',
+  id: 'a_document_id',
+  doc: {
+    author: 'S.E. Hinton',
+    new_field: 'new value'
+  }
+})
 ```
 
 ### Deleting a document
@@ -132,7 +142,10 @@ You can call the `update` API to update a document:
 You can call the `delete` API to delete a document:
 
 ```js
-
+await client.delete({
+  index: 'books',
+  id: 'a_document_id',
+})
 ```
 
 
@@ -140,7 +153,7 @@ You can call the `delete` API to delete a document:
 
 
 ```js
-
+await client.indices.delete({ index: 'books' })
 ```
 
 


### PR DESCRIPTION
# Overview

This PR adds four new sections to the getting started page: Getting a document, Updating a document, Deleting a document, and Deleting an index. This way, the serverless getting started page covers the same operations as the getting started page of the fully-managed client.