### PR TITLE
Use esv service key in telemetry header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -202,7 +202,7 @@ export default class Client extends API {
     }
 
     if (options.enableMetaHeader) {
-      options.headers['x-elastic-client-meta'] = `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
+      options.headers['x-elastic-client-meta'] = `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
     }
 
     this.name = options.name
@@ -265,7 +265,7 @@ export default class Client extends API {
     this.helpers = new Helpers({
       client: this,
       metaHeader: options.enableMetaHeader
-        ? `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
+        ? `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
         : null,
       maxRetries: options.maxRetries
     })

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -365,7 +365,7 @@ test('Meta header enabled by default', async t => {
 
   const Connection = connection.buildMockConnection({
     onRequest (opts) {
-      t.match(opts.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}` })
+      t.match(opts.headers, { 'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}` })
       return {
         statusCode: 200,
         body: { hello: 'world' }

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -56,7 +56,7 @@ test('bulk index', t => {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, {
             'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+            'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
@@ -103,7 +103,7 @@ test('bulk index', t => {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
           t.notMatch(params.headers, {
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+            'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
@@ -1320,7 +1320,7 @@ test('Flush interval', t => {
         t.equal(params.path, '/_bulk')
         t.match(params.headers, {
           'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
-          'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+          'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
         })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')

--- a/test/unit/helpers/scroll.test.ts
+++ b/test/unit/helpers/scroll.test.ts
@@ -36,7 +36,7 @@ test('Scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.match(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
+        'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
       })
 
       count += 1
@@ -92,7 +92,7 @@ test('Clear a scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.notMatch(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
+        'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
       })
       if (params.method === 'DELETE') {
         // @ts-expect-error


### PR DESCRIPTION
Uses new `esv` service key to track serverless client usage in telemetry.
