### PR TITLE
Update telemetry string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -56,6 +56,7 @@ if (clientVersion.includes('-')) {
   // clean prerelease
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
+const clientVersionNoMeta = clientVersion.split('+')[0]
 let transportVersion: string = require('@elastic/transport/package.json').version // eslint-disable-line
 /* istanbul ignore next */
 if (transportVersion.includes('-')) {
@@ -202,7 +203,7 @@ export default class Client extends API {
     }
 
     if (options.enableMetaHeader) {
-      options.headers['x-elastic-client-meta'] = `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
+      options.headers['x-elastic-client-meta'] = `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
     }
 
     this.name = options.name
@@ -265,7 +266,7 @@ export default class Client extends API {
     this.helpers = new Helpers({
       client: this,
       metaHeader: options.enableMetaHeader
-        ? `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
+        ? `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}`
         : null,
       maxRetries: options.maxRetries
     })

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -363,9 +363,10 @@ test('name as symbol', t => {
 test('Meta header enabled by default', async t => {
   t.plan(1)
 
+  const clientVersionNoMeta = clientVersion.split('+')[0]
   const Connection = connection.buildMockConnection({
     onRequest (opts) {
-      t.match(opts.headers, { 'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}` })
+      t.match(opts.headers, { 'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion}` })
       return {
         statusCode: 200,
         body: { hello: 'world' }

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -30,6 +30,7 @@ let clientVersion: string = require('../../../package.json').version // eslint-d
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
+const clientVersionNoMeta = clientVersion.split('+')[0]
 let transportVersion: string = require('@elastic/transport/package.json').version // eslint-disable-line
 if (transportVersion.includes('-')) {
   transportVersion = transportVersion.slice(0, transportVersion.indexOf('-')) + 'p'
@@ -56,7 +57,7 @@ test('bulk index', t => {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, {
             'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
-            'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+            'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
@@ -103,7 +104,7 @@ test('bulk index', t => {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
           t.notMatch(params.headers, {
-            'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+            'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
@@ -1320,7 +1321,7 @@ test('Flush interval', t => {
         t.equal(params.path, '/_bulk')
         t.match(params.headers, {
           'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
-          'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
+          'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
         })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')

--- a/test/unit/helpers/scroll.test.ts
+++ b/test/unit/helpers/scroll.test.ts
@@ -25,6 +25,7 @@ let clientVersion: string = require('../../../package.json').version // eslint-d
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
+let clientVersionNoMeta = clientVersion.split('+')[0]
 let transportVersion: string = require('@elastic/transport/package.json').version // eslint-disable-line
 if (transportVersion.includes('-')) {
   transportVersion = transportVersion.slice(0, transportVersion.indexOf('-')) + 'p'
@@ -36,7 +37,7 @@ test('Scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.match(params.headers, {
-        'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
+        'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
       })
 
       count += 1
@@ -92,7 +93,7 @@ test('Clear a scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.notMatch(params.headers, {
-        'x-elastic-client-meta': `esv=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
+        'x-elastic-client-meta': `esv=${clientVersionNoMeta},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=s`
       })
       if (params.method === 'DELETE') {
         // @ts-expect-error


### PR DESCRIPTION
We decided to not include version metadata (API version) in the telemetry client meta header.
