### PR TITLE
Add missing conf. catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -35,8 +35,9 @@ spec:
           access_level: READ_ONLY
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'
-      build_branches: false
-      build_tags: false
+      provider_settings:
+        build_branches: false
+        build_tags: false
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       schedules:


### PR DESCRIPTION
The **build_branches** and **build_tags attributes** must to be specify under the `provider_settings` config. 
https://github.com/elastic/ci/blob/main/terrazzo/terrazzo/config/defaults/buildkite/pipelines.py

Otherwise, Backstage/Terrazzo do not recognise them and `catalog-info.yam`l turn out to be an invalid configuration file, so Terrazzo will try to delete the resources it contains: https://buildkite.com/elastic/terrazzo/builds/27884#018b4aa9-6d58-4176-9311-2fc443d2ee83/6-5848

