### PR TITLE
Fix Docker permissions for CI

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get clean -y && \
 WORKDIR /usr/src/app
 
 COPY package*.json .
-RUN npm install --omit=dev
+RUN npm install
 
 COPY . .

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get clean -y && \
 WORKDIR /usr/src/app
 
 COPY package*.json .
-RUN npm install --production=false
+RUN npm install --omit=dev
 
 COPY . .

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -22,7 +22,6 @@ export GITHUB_TOKEN
 
 mkdir -p "$repo/junit-output"
 docker run \
-       -u "$(id -u):$(id -g)" \
        -e "ELASTICSEARCH_URL" \
        -e "ES_API_SECRET_KEY" \
        -e "GITHUB_TOKEN" \

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -20,7 +20,6 @@ echo "--- :javascript: Running tests"
 GITHUB_TOKEN=$(vault read -field=token "$GITHUB_TOKEN_PATH")
 export GITHUB_TOKEN
 
-mkdir -p "$repo/junit-output"
 docker run \
        -e "ELASTICSEARCH_URL" \
        -e "ES_API_SECRET_KEY" \

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -20,7 +20,9 @@ echo "--- :javascript: Running tests"
 GITHUB_TOKEN=$(vault read -field=token "$GITHUB_TOKEN_PATH")
 export GITHUB_TOKEN
 
+mkdir -p "$repo/junit-output"
 docker run \
+       -u "$(id -u):$(id -g)" \
        -e "ELASTICSEARCH_URL" \
        -e "ES_API_SECRET_KEY" \
        -e "GITHUB_TOKEN" \

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -159,7 +159,6 @@ else
   docker run \
     --volume "$repo:/usr/src/app" \
     --volume /usr/src/app/node_modules \
-    -u "$(id -u):$(id -g)" \
     --env "WORKFLOW=$WORKFLOW" \
     --name make-elasticsearch-js \
     --rm \

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -147,7 +147,6 @@ if [[ -z "${BUILDKITE+x}" ]] || [[ -z "${CI+x}" ]]; then
   docker run \
     --volume "$repo:/usr/src/app" \
     --volume "$(realpath $repo/../elastic-client-generator-js):/usr/src/elastic-client-generator-js" \
-    -u "$(id -u):$(id -g)" \
     --env "WORKFLOW=$WORKFLOW" \
     --name make-elasticsearch-js \
     --rm \

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ npm-debug.log
 .git
 .nyc_output
 lib
+junit-output


### PR DESCRIPTION
Mounted volumes in containers currently have a mix of permissions set up that are either root or the current user. Making everything consistent to clear up some perms issues in CI jobs.
