### PR TITLE
Ensure Docker installs dependencies cleanly

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get clean -y && \
 
 WORKDIR /usr/src/app
 
-COPY package*.json .
+COPY package.json .
 RUN npm install
 
 COPY . .

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ npm-debug.log
 .nyc_output
 lib
 junit-output
+package-lock.json


### PR DESCRIPTION
The Github action to run codegen on this repo is failing due to a dev dependency not being available. Ensuring a clean install by dropping package-lock.json from Docker.
