### PR TITLE
Unraveling some Docker/Node.js dependency weirdness

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -166,6 +166,7 @@ else
       git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git && \
       mkdir -p /usr/src/elastic-client-generator-js/output && \
       cd /usr/src/app && \
+      npm ls -a && \
       node .ci/make.mjs --task $TASK ${TASK_ARGS[*]}"
 fi
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,3 @@ node_modules
 npm-debug.log
 .git
 .nyc_output
-lib
-junit-output
-package-lock.json


### PR DESCRIPTION
A Github action from another repo is erroring out when running `.ci/make.sh`, with the error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zx' imported from /usr/src/app/.ci/make.mjs
```

This is an experimental fix to that problem.
