### PR TITLE
Use non-root user in Docker when running codegen

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,16 +1,32 @@
 ARG NODE_VERSION=${NODE_VERSION:-18}
 FROM node:$NODE_VERSION
 
+ARG BUILDER_USER=1000
+ARG BUILDER_GROUP=1000
+
 # Install zip util
 RUN apt-get clean -y && \
-    apt-get -qy update && \
-    apt-get -y install zip && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get update -y && \
+    apt-get install -y zip
+
+# Set up all files as owned by non-root user
+RUN groupadd -f --system -g ${BUILDER_GROUP} elastic \
+    && (id -u ${BUILDER_USER} 2>&1 /dev/null || useradd --system --shell /bin/bash -u ${BUILDER_USER} -g ${BUILDER_GROUP} -m elastic 2>&1 /dev/null) \
+    && mkdir -p /usr/src/app \
+    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /usr/src/ \
+    && mkdir -p /.npm \
+    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /.npm \
+    && mkdir -p /.cache \
+    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /.cache
 
 WORKDIR /usr/src/app
 
-COPY package.json .
-RUN npm install
+# run remainder of commands as non-root user
+USER ${BUILDER_USER}:${BUILDER_GROUP}
 
+# install dependencies
+COPY package.json .
+RUN npm install --production=false
+
+# copy project files
 COPY . .

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get clean -y && \
 
 # Set up all files as owned by non-root user
 RUN groupadd -f --system -g ${BUILDER_GROUP} elastic \
-    && (id -u ${BUILDER_USER} 2>&1 /dev/null || useradd --system --shell /bin/bash -u ${BUILDER_USER} -g ${BUILDER_GROUP} -m elastic 2>&1 /dev/null) \
+    && (id -u ${BUILDER_USER} || useradd --system --shell /bin/bash -u ${BUILDER_USER} -g ${BUILDER_GROUP} -m elastic) \
     && mkdir -p /usr/src/app \
     && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /usr/src/ \
     && mkdir -p /.npm \

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -6,13 +6,15 @@ script_path=$(dirname "$(realpath -s "$0")")
 set -euo pipefail
 repo=$(pwd)
 
-export NODE_VERSION=${NODE_VERSION:-16}
+export NODE_VERSION=${NODE_VERSION:-18}
 
 echo "--- :docker: Building Docker image"
 docker build \
        --file "$script_path/Dockerfile" \
        --tag elastic/elasticsearch-serverless-js \
        --build-arg NODE_VERSION="$NODE_VERSION" \
+       --build-arg BUILDER_USER="$(id -u)" \
+       --build-arg BUILDER_GROUP="$(id -g)" \
        .
 
 echo "--- :javascript: Running tests"
@@ -22,6 +24,7 @@ export GITHUB_TOKEN
 
 mkdir -p "$repo/junit-output"
 docker run \
+       -u "$(id -u):$(id -g)" \
        -e "ELASTICSEARCH_URL" \
        -e "ES_API_SECRET_KEY" \
        -e "GITHUB_TOKEN" \


### PR DESCRIPTION
Using a non-root user when running Docker in CI to avoid permissions-related failures during automated codegen.
