### PR TITLE
Improve unit test path filtering rules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,31 +1,36 @@
 ---
 name: Unit tests
 on:
-  push:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.asciidoc'
-      - '**/*.txt'
-      - 'docs/**'
-      - '.ci/**'
-      - '.buildkite/**'
-      - 'scripts/**'
-      - 'catalog-info.yaml'
-  pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.asciidoc'
-      - '**/*.txt'
-      - 'docs/**'
-      - '.ci/**'
-      - '.buildkite/**'
-      - 'scripts/**'
-      - 'catalog-info.yaml'
+  pull_request: {}
 
 jobs:
+  paths-filter:
+    name: Detect files changed
+    runs-on: ubuntu-latest
+    outputs:
+      skip: '${{ steps.changes.outputs.skip }}'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter/@v2.11.1
+        id: changes
+        with:
+          filters: |
+            skip:
+              - '**/*.md'
+              - '**/*.asciidoc'
+              - '**/*.txt'
+              - 'docs/**'
+              - '.ci/**'
+              - '.buildkite/**'
+              - 'scripts/**'
+              - 'catalog-info.yaml'
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    needs: paths-filter
+    # only run if files not in `skip` filter were changed
+    if: needs.paths-filter.outputs.skip != 'true'
 
     strategy:
       matrix:
@@ -33,7 +38,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -61,7 +66,7 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "clean-build": "rimraf ./lib && mkdir lib",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint && tap test/unit/{*,**/*}.test.ts && npm run license-checker",
+    "test": "npm run build && npm run lint && tap test/unit/{*,**/*}.test.ts",
     "test:coverage-100": "npm run build && tap test/unit/{*,**/*}.test.ts --coverage --100",
     "test:coverage-report": "npm run build && tap test/unit/{*,**/*}.test.ts --coverage && nyc report --reporter=text-lcov > coverage.lcov",
     "test:coverage-ui": "npm run build && tap test/unit/{*,**/*}.test.ts --coverage --coverage-report=html",


### PR DESCRIPTION
Near-identical PR on the stack client: https://github.com/elastic/elasticsearch-js/pull/2052

Also stops running license checker redundantly during unit tests job.
