### PR TITLE
Stop supporting Node v16

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,6 @@ steps:
     matrix:
       setup:
         nodejs:
-          - "16"
           - "18"
           - "20"
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -19,7 +19,7 @@ Elasticsearch operations with it.
 
 ## Requirements
 
-* Node.js 16 or higher installed on your system.
+* Node.js 18 or higher installed on your system.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/elastic/elasticsearch-serverless-js",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",


### PR DESCRIPTION
v16 is [EOL](https://endoflife.date/nodejs). Code will likely still run just fine on 16 for quite a while, but moving forward we'll reserve the right to start using features introduced in Node.js v18. For now it mostly means just not running test suites against v16.
