### PR TITLE
Throw an explicit error when asStream is used with bulk helper

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -524,6 +524,8 @@ export default class Helpers {
    * @return {object} The possible operations to run with the datasource.
    */
   bulk<TDocument = unknown> (options: BulkHelperOptions<TDocument>, reqOptions: TransportRequestOptions = {}): BulkHelper<TDocument> {
+    assert(!(reqOptions.asStream ?? false), 'bulk helper: the asStream request option is not supported')
+
     const client = this[kClient]
     const { serializer } = client
     if (this[kMetaHeader] !== null) {

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { AssertionError } from 'assert'
 import * as http from 'http'
 import { createReadStream } from 'fs'
 import { join } from 'path'
@@ -1159,6 +1160,36 @@ test('transport options', t => {
       failed: 0,
       aborted: false
     })
+  })
+
+  t.test('Should not allow asStream request option', async t => {
+    t.plan(2)
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+    })
+
+    try {
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        onDrop (doc) {
+          t.fail('This should never be called')
+        },
+      }, {
+        headers: {
+          foo: 'bar'
+        },
+        asStream: true,
+      })
+    } catch (err: any) {
+      t.ok(err instanceof AssertionError)
+      t.equal(err.message, 'bulk helper: the asStream request option is not supported')
+    }
   })
 
   t.end()


### PR DESCRIPTION
Porting https://github.com/elastic/elasticsearch-js/commit/426919709f43e3680a696de8880c4203be1e4dab
