### PR TITLE
Add Github action to automate npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,28 @@
+name: Publish package to npm
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Git branch to build and publish'
+        required: true
+        default: main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm
+      - run: npm install
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Automates publishing to npm by manually triggering a Github action pointed at the branch to be published (defaults to `main`).

Also includes necessary configurations to include a [provenance statement](https://docs.npmjs.com/generating-provenance-statements) for each release, which helps to improve supply-chain security.
