### PR TITLE
Apply patch from elastic/elasticsearch-js#2078

### DIFF
--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -914,6 +914,37 @@ test('bulk update', t => {
     })
   })
 
+  t.test('Should not allow asStream request option', async t => {
+    t.plan(2)
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+    })
+
+    try {
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        onDrop (doc) {
+          t.fail('This should never be called')
+        },
+        refreshOnCompletion: true
+      }, {
+        headers: {
+          foo: 'bar'
+        },
+        asStream: true,
+      })
+    } catch (err: any) {
+      t.ok(err instanceof AssertionError)
+      t.equal(err.message, 'bulk helper: the asStream request option is not supported')
+    }
+  })
+
   t.end()
 })
 

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -1192,36 +1192,6 @@ test('transport options', t => {
     })
   })
 
-  t.test('Should not allow asStream request option', async t => {
-    t.plan(2)
-
-    const client = new Client({
-      node: 'http://localhost:9200',
-    })
-
-    try {
-      await client.helpers.bulk({
-        datasource: dataset.slice(),
-        flushBytes: 1,
-        concurrency: 1,
-        onDocument (doc) {
-          return { index: { _index: 'test' } }
-        },
-        onDrop (doc) {
-          t.fail('This should never be called')
-        },
-      }, {
-        headers: {
-          foo: 'bar'
-        },
-        asStream: true,
-      })
-    } catch (err: any) {
-      t.ok(err instanceof AssertionError)
-      t.equal(err.message, 'bulk helper: the asStream request option is not supported')
-    }
-  })
-
   t.end()
 })
 

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -932,7 +932,6 @@ test('bulk update', t => {
         onDrop (doc) {
           t.fail('This should never be called')
         },
-        refreshOnCompletion: true
       }, {
         headers: {
           foo: 'bar'

--- a/test/unit/helpers/bulk.test.ts.rej
+++ b/test/unit/helpers/bulk.test.ts.rej
@@ -1,0 +1,9 @@
+diff a/test/unit/helpers/bulk.test.ts b/test/unit/helpers/bulk.test.ts	(rejected hunks)
+@@ -18,6 +18,7 @@
+  */
+ 
+ import FakeTimers from '@sinonjs/fake-timers'
++import { AssertionError } from 'assert'
+ import { createReadStream } from 'fs'
+ import * as http from 'http'
+ import { join } from 'path'

--- a/test/unit/helpers/bulk.test.ts.rej
+++ b/test/unit/helpers/bulk.test.ts.rej
@@ -1,9 +1,0 @@
-diff a/test/unit/helpers/bulk.test.ts b/test/unit/helpers/bulk.test.ts	(rejected hunks)
-@@ -18,6 +18,7 @@
-  */
- 
- import FakeTimers from '@sinonjs/fake-timers'
-+import { AssertionError } from 'assert'
- import { createReadStream } from 'fs'
- import * as http from 'http'
- import { join } from 'path'


### PR DESCRIPTION
Patch applied from elastic/elasticsearch-js#2078

## Rejected patch `./src/helpers.ts.rej` must be resolved:

```diff
diff a/src/helpers.ts b/src/helpers.ts	(rejected hunks)
@@ -527,6 +527,8 @@ export default class Helpers {
    * @return {object} The possible operations to run with the datasource.
    */
   bulk<TDocument = unknown> (options: BulkHelperOptions<TDocument>, reqOptions: TransportRequestOptions = {}): BulkHelper<TDocument> {
+    assert(!(reqOptions.asStream ?? false), 'bulk helper: the asStream request option is not supported')
+
     const client = this[kClient]
     const { serializer } = client
     if (this[kMetaHeader] !== null) {
```

