### PR TITLE
Use unique name for serverless client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -168,7 +168,7 @@ export default class Client extends API {
         'elastic-api-version': `${apiVersion.slice(0, 4)}-${apiVersion.slice(4, 6)}-${apiVersion.slice(6, 8)}`
       },
       generateRequestId: null,
-      name: 'elasticsearch-js',
+      name: 'elasticsearch-serverless-js',
       auth: null,
       opaqueIdPrefix: null,
       context: null,


### PR DESCRIPTION
Fixes <https://github.com/elastic/elasticsearch-serverless-js/issues/74>
