### PR TITLE
Upgrade transport to 8.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.6.1",
+    "@elastic/transport": "^8.7.0",
     "tslib": "^2.5.0"
   },
   "tap": {


### PR DESCRIPTION
Ensures next release will include support for OpenTelemetry. See https://github.com/elastic/elastic-transport-js/pull/104.
